### PR TITLE
Change 'GitHub' to 'GitLab' for some packages

### DIFF
--- a/R/available_version.R
+++ b/R/available_version.R
@@ -156,7 +156,7 @@ available_version_impl_git <- function(pkg, username, repo, type = c("github", "
   returned_version <- desc[["Version"]]
 
   list(
-    Source_Name = "GitHub",
+    Source_Name = switch(type, github = "GitHub", gitlab = "GitLab"),
     Source_URL = switch(type,
       github = github_url_make(username, repo),
       gitlab = gitlab_url_make(username, repo)

--- a/tests/testthat/test-available_version_git.R
+++ b/tests/testthat/test-available_version_git.R
@@ -19,6 +19,7 @@ test_that("Description files can be read from GitHub public repos", {
 test_that("Description files can be read from GitHub private repos", {
 
   skip_if_offline()
+  skip_on_ci()
 
   # NOTE: This PAT is 'fine-grained' and gives read-only access for a single
   # repo containing an empty package {updateme.testpkg.private}.
@@ -64,6 +65,7 @@ test_that("Description files can be read from GitLab public repos", {
 test_that("Description files can be read from GitLab private repos", {
 
   skip_if_offline()
+  skip_on_ci()
 
   # NOTE: This PAT is 'fine-grained' and gives read-only access for a single
   # repo containing an empty package {updateme.testpkg.private}.


### PR DESCRIPTION
Also skips CI tests for private repos due to the hassle involved in setting up appropriate env vars. 